### PR TITLE
chore: limit backend CI to master PRs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,11 +1,9 @@
 name: Backend Coverage Check
 
 on:
-  push:
-    paths:
-      - 'backend/**'
-      - '.github/workflows/backend-ci.yml'
   pull_request:
+    branches:
+      - master
     paths:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'


### PR DESCRIPTION
## Summary
- run backend CI workflow only when PR targets master

## Testing
- not run