### PR TITLE
chore: harden backend ci checks

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,11 +29,19 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Install tooling
+        run: |
+          go install github.com/google/wire/cmd/wire@v0.6.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+
       - name: Verify Wire generated code
         run: make wire-check
 
       - name: Static analysis
         run: make vet
+
+      - name: Run lint
+        run: make lint
 
       - name: Run coverage check
         run: make coverage-check
@@ -44,3 +52,7 @@ jobs:
         with:
           name: backend-coverage
           path: backend/coverage.txt
+
+      - name: Clean coverage artifacts
+        if: always()
+        run: rm -f coverage.out coverage.txt

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -101,7 +101,9 @@ fmt:
 
 # 代码检查
 vet:
-	@echo "Running go vet..."
+	@echo "Running go vet (default build)..."
+	go vet ./...
+	@echo "Running go vet (wireinject build)..."
 	go vet -tags=wireinject ./...
 
 # 运行所有检查（格式化、vet、测试）


### PR DESCRIPTION
## Summary
- run go vet for both default and wireinject builds to cover generated and runtime code
- install wire and golangci-lint up front, enforce make wire-check, vet, and lint in CI
- keep coverage artifacts tidy after upload

## Testing
- make vet
- make coverage-check
